### PR TITLE
sbt-scalariformを1.5.1に更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .ensime
-.ensime_lucene
+.ensime_*
 
 logs
 project/project

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ scala:
    - 2.10.4
 
 branches:
+   - overlay-weaver
    - master
-   - develop
 
 jdk:
    - oraclejdk7

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ P2P2ch
 P2P2ch 1.10
 2ch like p2p bbs by Scala
   
-[![Build Status](https://travis-ci.org/Hiroyuki-Nagata/p2p2ch.svg?branch=master)](https://travis-ci.org/Hiroyuki-Nagata/p2p2ch)[![BSD 3 clause license](http://img.shields.io/badge/license-BSD-lightgrey.svg?style=flat)](https://github.com/Hiroyuki-Nagata/p2p2ch/blob/master/LICENSE)
+[![Build Status](https://travis-ci.org/Hiroyuki-Nagata/p2p2ch.svg?branch=overlay-weaver)](https://travis-ci.org/Hiroyuki-Nagata/p2p2ch)[![BSD 3 clause license](http://img.shields.io/badge/license-BSD-lightgrey.svg?style=flat)](https://github.com/Hiroyuki-Nagata/p2p2ch/blob/master/LICENSE)
 
 **このプロジェクトは実験段階です。**
 そのためバージョンアップの際の互換性は考慮されていません。
@@ -15,8 +15,6 @@ P2P2ch 1.10
 For developers
 --------------
 ### ビルド
-
-- sbt 0.13.6 を使用することが望ましい
 
 ```
 $ git clone https://github.com/windymelt/p2p2ch 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -75,7 +75,7 @@ object Application extends Controller {
       val params = new ThreadBuildingFormExtractor().extract
       val buildResult = new ThreadBuilder().buildThread(params.subject, params.FROM, params.mail, params.MESSAGE)
       buildResult match {
-        case \/-(_)     ⇒ Ok(views.html.threadPostSuccessful()).as(HTML)
+        case \/-(_) ⇒ Ok(views.html.threadPostSuccessful()).as(HTML)
         case -\/(error) ⇒ Ok(views.html.threadBuildFailed(error.message)).as(HTML)
       }
     } else {
@@ -87,7 +87,7 @@ object Application extends Controller {
         case threadDatNumber ⇒
           val writeResult = new ThreadWriter().writeThread(threadDatNumber, params.FROM, params.mail, params.MESSAGE)
           writeResult match {
-            case \/-(_)     ⇒ Ok(views.html.threadPostSuccessful()).as(HTML)
+            case \/-(_) ⇒ Ok(views.html.threadPostSuccessful()).as(HTML)
             case -\/(error) ⇒ Ok(views.html.threadWriteFailed(error.message)).as(HTML)
           }
       }

--- a/app/controllers/CacheUpdater.scala
+++ b/app/controllers/CacheUpdater.scala
@@ -7,7 +7,7 @@ import scala.util.control.Exception.ignoring
 object CacheUpdater {
   // TODO: case classに置換したい
   def updateLocalCache(
-    threadUpdates:   List[(Symbol, Array[Byte], Long)],
+    threadUpdates: List[(Symbol, Array[Byte], Long)],
     responseUpdates: List[(Symbol, Array[Byte], Array[Byte], Long)]
   ) = {
     Logger.debug(s"updating local key table: ${threadUpdates.size} thread, ${responseUpdates.size} response")

--- a/app/controllers/DataFetchingBeacon.scala
+++ b/app/controllers/DataFetchingBeacon.scala
@@ -11,8 +11,8 @@ class DataFetchingBeacon extends akka.actor.Actor {
 
   def receive = {
     case ('start, a: ActorRef) ⇒ startTimer(a)
-    case 'stop                 ⇒ stopTimer
-    case unknown               ⇒
+    case 'stop ⇒ stopTimer
+    case unknown ⇒
   }
 
   def startTimer(a: ActorRef) = {
@@ -22,7 +22,7 @@ class DataFetchingBeacon extends akka.actor.Actor {
 
   def stopTimer = {
     cancellable >>= (c ⇒ c.isCancelled match {
-      case false     ⇒ c.cancel().some
+      case false ⇒ c.cancel().some
       case otherwise ⇒ None // do nothing
     })
     cancellable = None

--- a/app/controllers/Information.scala
+++ b/app/controllers/Information.scala
@@ -26,7 +26,7 @@ object Information {
     }.mkString(_BR_)
     log match {
       case "" ⇒ str
-      case s  ⇒ str + _BR_ + log
+      case s ⇒ str + _BR_ + log
     }
   }
 
@@ -47,13 +47,13 @@ object Information {
     message.nonEmpty match {
       case true ⇒
         message.split(_BR_).toList match {
-          case Help()            ⇒ Help.work
-          case Reference()       ⇒ Reference.work
-          case Join(reference)   ⇒ Join.work(reference)
-          case Status()          ⇒ Status.work
-          case Upload(path)      ⇒ Upload.work(path)
+          case Help() ⇒ Help.work
+          case Reference() ⇒ Reference.work
+          case Join(reference) ⇒ Join.work(reference)
+          case Status() ⇒ Status.work
+          case Upload(path) ⇒ Upload.work(path)
           case ExternalAddress() ⇒ ExternalAddress.work
-          case _                 ⇒ "そんなコマンド知らん"
+          case _ ⇒ "そんなコマンド知らん"
         }
       case false ⇒ "空白は困ります"
     }
@@ -64,7 +64,7 @@ object Help {
   def unapply(x: Any): Boolean = {
     x.isInstanceOf[List[String]] && (x.asInstanceOf[List[String]] match {
       case "help" :: Nil ⇒ true
-      case _             ⇒ false
+      case _ ⇒ false
     })
   }
 
@@ -89,7 +89,7 @@ object Reference {
   def unapply(x: Any): Boolean = {
     x.isInstanceOf[List[String]] && (x.asInstanceOf[List[String]] match {
       case "reference" :: Nil ⇒ true
-      case _                  ⇒ false
+      case _ ⇒ false
     })
   }
 
@@ -102,7 +102,7 @@ object Join {
   def unapply(x: Any): Option[String] = {
     x match {
       case "join" :: (reference: String) :: Nil ⇒ Some(reference)
-      case _                                    ⇒ None
+      case _ ⇒ None
     }
   }
 
@@ -116,7 +116,7 @@ object Status {
   def unapply(x: Any): Boolean = {
     x.isInstanceOf[List[String]] && (x.asInstanceOf[List[String]] match {
       case "status" :: Nil ⇒ true
-      case _               ⇒ false
+      case _ ⇒ false
     })
   }
 
@@ -129,7 +129,7 @@ object Upload {
   def unapply(x: Any): Option[String] = {
     x match {
       case "upload" :: (path_to_file: String) :: Nil ⇒ Some(path_to_file)
-      case _                                         ⇒ None
+      case _ ⇒ None
     }
   }
 
@@ -142,7 +142,7 @@ object ExternalAddress {
   def unapply(x: Any): Boolean = {
     x.isInstanceOf[List[String]] && (x.asInstanceOf[List[String]] match {
       case "extnaddr" :: Nil ⇒ true
-      case _                 ⇒ false
+      case _ ⇒ false
     })
   }
 

--- a/app/controllers/Receiver2ch.scala
+++ b/app/controllers/Receiver2ch.scala
@@ -13,10 +13,10 @@ class Receiver2ch(stateAgt: Agent[ChordState]) extends MessageReceiver(stateAgt:
   val fetcher = context.actorOf(akka.actor.Props[DataFetchingBeacon], "FetchingBeacon")
 
   override def receiveExtension(x: Any, sender: ActorRef)(implicit context: ActorContext) = x match {
-    case ('NewResSince, time: Long)    ⇒ sender ! LocalDatabase.default.getResponsesAfter(time)
+    case ('NewResSince, time: Long) ⇒ sender ! LocalDatabase.default.getResponsesAfter(time)
     case ('NewThreadSince, time: Long) ⇒ sender ! LocalDatabase.default.getThreadsAfter(time)
-    case PullNew                       ⇒ pullNewData
-    case m                             ⇒ log.warning(s"unknown message: $m")
+    case PullNew ⇒ pullNewData
+    case m ⇒ log.warning(s"unknown message: $m")
   }
 
   override def preStart = {

--- a/app/controllers/Utility.scala
+++ b/app/controllers/Utility.scala
@@ -14,7 +14,7 @@ object Utility {
 
   def nanasify(name: String): String = name match {
     case "" ⇒ "P2Pの名無しさん"
-    case s  ⇒ s
+    case s ⇒ s
   }
 
   val Otimestamp2str: Option[Long] ⇒ String =
@@ -38,7 +38,7 @@ object Utility {
     Some(s.toLong)
   } catch {
     case e: NumberFormatException ⇒ None
-    case _: Throwable             ⇒ None
+    case _: Throwable ⇒ None
   }
 
 }

--- a/app/controllers/dht/DHTOverlayWeaver.scala
+++ b/app/controllers/dht/DHTOverlayWeaver.scala
@@ -42,7 +42,7 @@ object DHTOverlayWeaver extends controllers.dht.DHT {
     case Some(d) ⇒
       val v = d.get(ID.getID(key.toArray, ID_SIZE))
       v.iterator().hasNext match {
-        case true  ⇒ Future(v.iterator().next().getValue.toStream.right)
+        case true ⇒ Future(v.iterator().next().getValue.toStream.right)
         case false ⇒ Future(DHTNotFound.left)
       }
     case None ⇒ Future(DHTGetNotInitialized.left)
@@ -68,9 +68,9 @@ object DHTOverlayWeaver extends controllers.dht.DHT {
   def identifier: Option[Identifier] = dht() flatMap { _.getSelfIDAddressPair.toString.some }
   def info: Option[Information] = dht() flatMap { _.getConfiguration.toString.some }
   private def initializeDHT(applicationID: Short, applicationVersion: Short, config: DHTConfiguration,
-                            workingDir: Option[String], transport: Option[String], algorithm: Option[String],
-                            routingStyle: Option[String], selfID: Option[ID], statCollectorAddressAndPort: Option[String],
-                            selfAddressAndPort: Option[String], noUPnP: Boolean = false, contactHostAndPort: Option[String]): OWDHT[V] = {
+    workingDir: Option[String], transport: Option[String], algorithm: Option[String],
+    routingStyle: Option[String], selfID: Option[ID], statCollectorAddressAndPort: Option[String],
+    selfAddressAndPort: Option[String], noUPnP: Boolean = false, contactHostAndPort: Option[String]): OWDHT[V] = {
     var join = false
 
     contactHostAndPort foreach { _ ⇒ join = true }

--- a/app/controllers/localdb/SQLLocalDatabase.scala
+++ b/app/controllers/localdb/SQLLocalDatabase.scala
@@ -12,7 +12,7 @@ object SQLLocalDatabase extends LocalDatabase {
       implicit c ⇒
         SQL("SELECT THREAD FROM THREAD_CACHE WHERE MODIFIED = {modified}").on("modified" → datNumber)().map {
           case Row(thread: Array[Byte]) ⇒ Some(thread)
-          case _                        ⇒ None
+          case _ ⇒ None
         }.filterNot(_.isEmpty).toList
     }
     threadKeyList(0)

--- a/app/controllers/threadbuilding/WriteRequestT.scala
+++ b/app/controllers/threadbuilding/WriteRequestT.scala
@@ -1,11 +1,11 @@
 package controllers.threadbuilding
 
 case class WriteRequestT(
-  bbs:     String,
-  time:    String,
-  submit:  String,
-  FROM:    String,
-  mail:    String,
+  bbs: String,
+  time: String,
+  submit: String,
+  FROM: String,
+  mail: String,
   MESSAGE: String,
   subject: String
 )

--- a/app/controllers/threadwriting/WriteRequestR.scala
+++ b/app/controllers/threadwriting/WriteRequestR.scala
@@ -1,11 +1,11 @@
 package controllers.threadwriting
 
 case class WriteRequestR(
-  bbs:     String,
-  key:     Long,
-  time:    String,
-  submit:  String,
-  FROM:    String,
-  mail:    String,
+  bbs: String,
+  key: Long,
+  time: String,
+  submit: String,
+  FROM: String,
+  mail: String,
   MESSAGE: String
 )

--- a/app/controllers/upnp/UPnP.scala
+++ b/app/controllers/upnp/UPnP.scala
@@ -3,11 +3,11 @@ package controllers.upnp
 import scala.concurrent.duration.FiniteDuration
 
 abstract class UPnP(
-  val external_port: Int,
-  val local_port:    Int,
-  val protocol:      String,
-  val description:   String,
-  val limit:         FiniteDuration
+    val external_port: Int,
+    val local_port: Int,
+    val protocol: String,
+    val description: String,
+    val limit: FiniteDuration
 ) {
   def open(): Boolean
   def close(): Boolean

--- a/app/controllers/upnp/UPnPPsyonik.scala
+++ b/app/controllers/upnp/UPnPPsyonik.scala
@@ -5,11 +5,11 @@ import scala.concurrent.duration.FiniteDuration
 import play.api.Logger
 
 class UPnPPsyonik(
-  override val external_port: Int,
-  override val local_port:    Int,
-  override val protocol:      String,
-  override val description:   String,
-  override val limit:         FiniteDuration
+    override val external_port: Int,
+    override val local_port: Int,
+    override val protocol: String,
+    override val description: String,
+    override val limit: FiniteDuration
 ) extends UPnP(external_port, local_port, protocol, description, limit) {
   def open(): Boolean = GatewayDiscover().getValidGateway() exists { gw: GatewayDevice ⇒
     Logger.debug("UPnP: found Gateway")
@@ -27,7 +27,7 @@ class UPnPPsyonik(
   def close(): Boolean = GatewayDiscover().getValidGateway() exists { gw: GatewayDevice ⇒
     gw.getSpecificPortMappingEntry(external_port, protocol) match {
       case Some(_) ⇒ gw.deletePortMapping(external_port, protocol)
-      case None    ⇒ false
+      case None ⇒ false
     }
   }
 }

--- a/app/models/Response.scala
+++ b/app/models/Response.scala
@@ -48,7 +48,7 @@ object Response {
                       """ORDER BY MODIFIED ASC LIMIT 1 OFFSET {no}"""
                   ).on('thread → res.thread, 'no → decrN)().map {
                       case Row(response: Array[Byte]) ⇒ ">>" + new String(Base64.encodeBase64(response)) + "@"
-                      case _                          ⇒ ">>" + m.toString
+                      case _ ⇒ ">>" + m.toString
                     }.toList.headOption.getOrElse(">>" + m.toString)
               }
           }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.8

--- a/project/build.scala
+++ b/project/build.scala
@@ -11,7 +11,10 @@ import scalariform.formatter.preferences._
 object P2P2ch extends Build {
 
   lazy val P2PScalaProto =
-    ProjectRef(new URI("https://github.com/windymelt/p2pScalaProto.git"), "P2PScalaProto")
+    ProjectRef(new URI("https://github.com/Hiroyuki-Nagata/p2pScalaProto.git"), "P2PScalaProto")
+
+  // ローカルテスト用
+  // ProjectRef(base = file("../p2pScalaProto"), "P2PScalaProto")
 
   ScalariformKeys.preferences := ScalariformKeys.preferences.value
     .setPreference(RewriteArrowSymbols, true)

--- a/project/build.scala
+++ b/project/build.scala
@@ -72,6 +72,7 @@ object P2P2ch extends Build {
     resolvers += "Scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     libraryDependencies ++= LibraryDependencies
   )
+
   lazy val project = Project(
     "P2P2ch",
     file("."),
@@ -82,5 +83,5 @@ object P2P2ch extends Build {
         projectSettings
   ) dependsOn (
     P2PScalaProto
-    )
+  )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
 
 addSbtPlugin("org.ensime" % "ensime-sbt-cmd" % "0.1.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.4.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.3.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,10 +7,8 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
 
-addSbtPlugin("org.ensime" % "ensime-sbt-cmd" % "0.1.2")
-
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.4.0")
+addSbtPlugin("org.ensime" % "ensime-sbt" % "0.2.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.3.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.1")


### PR DESCRIPTION
ScalaRiformの上流の更新が途絶えておりensimeが使用できなかったため
以下のようにプラグインを更新

```
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.1")
```

参考: use maintained version of scalariform #20
https://github.com/sbt/sbt-scalariform/issues/20
